### PR TITLE
Player Dev Recruitment

### DIFF
--- a/InformationAgeProject/InformationAgeProject/GameController.cs
+++ b/InformationAgeProject/InformationAgeProject/GameController.cs
@@ -42,6 +42,9 @@ namespace InformationAgeProject
 		public static ProjectProgressDeck[] ProjProgDeck { get; set; }
 		public static AdditionalProjectFeaturesDeck ProjFeatDeck { get; set; }
 
+		public static bool recruitmentOfficeFull = false;
+		public static int playerAtRecruitmentOffice = 0;
+
 		#region GameController Constructor
 		/// <summary>
 		/// Private Constructor for GameController 
@@ -501,6 +504,20 @@ namespace InformationAgeProject
 			if (toolMakerFull == true)
 			{
 				acquireTool();
+			}
+
+			if (recruitmentOfficeFull == true)
+			{
+				//Create new recruitment office object, with the current number of the player's developers
+				int teamTotal = playerList[playerAtRecruitmentOffice].TeamCount;
+				RecruitmentOffice recruitmentOffice = new RecruitmentOffice(teamTotal);
+				//Recruit a new developer
+				int newTotalDevs = recruitmentOffice.RecruitNewDev();
+				//Add the new dev to player's total team count
+				playerList[playerAtRecruitmentOffice].TeamCount = newTotalDevs;
+				playerList[playerAtRecruitmentOffice].Developers = newTotalDevs;
+
+				recruitmentOfficeFull = false;
 			}
 
 			//Resets turn counter and increases the round counter

--- a/InformationAgeProject/InformationAgeProject/MainForm.cs
+++ b/InformationAgeProject/InformationAgeProject/MainForm.cs
@@ -50,7 +50,7 @@ namespace InformationAgeProject
 		private void MainForm_Load(object sender, EventArgs e)
 		{
 			//Loads initial developer count into txtDevelopers
-			this.txtDevelopers.Text = player.Developers.ToString();
+			this.txtDevelopers.Text = player.TeamCount.ToString();
 
 			//Loads initial progress cards into ProjectProgressCard textboxes
 			ProjectProgressCard1.Text = GameController.ProjProgDeck[GameController.turnCounter].Deck[0].displayCard();
@@ -84,8 +84,17 @@ namespace InformationAgeProject
 		public void Reload()
 		{
 			//Re-Loads developer count into txtDevelopers
-			this.txtDevelopers.Text = player.Developers.ToString();
+			this.txtDevelopers.Text = player.TeamCount.ToString();
+			lblRecruitStatus.Text = "";
 
+			if (GameController.recruitmentOfficeFull == true)
+            {
+				btnSendDevs.Enabled = false;
+            }
+			else
+            {
+				btnSendDevs.Enabled = true;
+            }
 
 			//Re-Loads tool levels into toolSlot textboxes
 			int[] toolLevelList = player.Inventory.getToolLevelList();
@@ -708,21 +717,17 @@ namespace InformationAgeProject
 		#endregion
 
 		/// <summary>
-		/// PLACEHOLDER EVENT: Only one player can use the recruitment office per round.
-		/// This event as is handles the recruitment office on a turn-by-turn basis.
-		/// Will need to be updated for round based functionality.
+		/// Sends two developers from the player's count of available devs.
+		/// The two devs, as well as one additional dev, are returned to the player at the round's end.
+		/// Only one player can use the recruitment office per round.
 		/// </summary>
 		/// <param name="sender"></param>
 		/// <param name="e"></param>
 		private void btnSendDevs_Click(object sender, EventArgs e)
 		{
-			//Create new recruitment office object, with the current number of the player's developers
-			RecruitmentOffice recruitmentOffice = new RecruitmentOffice(player.TeamCount);
-
 			//If the player has at least two developers
-			if (player.Developers >= 2)
+			if (player.Developers >= 2 & GameController.recruitmentOfficeFull == false)
 			{
-				int totalDevs = recruitmentOffice.RecruitNewDev();
 				btnSendDevs.Enabled = false;
 				lblRecruitStatus.Text = $"Recruitment Status:\n-----------------------" +
 					$"\nOccupied with 2 developers from Team:" +
@@ -731,6 +736,8 @@ namespace InformationAgeProject
 				player.Developers = player.Developers - 2;
 				txtDevelopers.Text = Convert.ToString(player.Developers);
 				btnRecallDevs.Enabled = true;
+				GameController.recruitmentOfficeFull = true;
+				GameController.playerAtRecruitmentOffice = GameController.turnCounter;
 			}
 			else
 			{
@@ -739,18 +746,22 @@ namespace InformationAgeProject
 		}
 
 		/// <summary>
-		/// PLACEHOLDER EVENT: Only one player can use the recruitment office per round.
-		/// This event as is handles the recruitment office on a turn-by-turn basis.
-		/// Will need to be updated for round based functionality.
+		/// If the current player has just just assigned two developers to the recruitment office,
+		/// pressing the recall button will remove the two devs and add them back to the player's
+		/// available developers count
 		/// </summary>
 		private void btnRecallDevs_Click(object sender, EventArgs e)
 		{
 			player.Developers = player.Developers + 2;
 			txtDevelopers.Text = Convert.ToString(player.Developers);
+			lblRecruitStatus.Text = "";
 			btnRecallDevs.Enabled = false;
 
 			if (player.Developers >= 2)
-				btnSendDevs.Enabled = true; 
+			{
+				btnSendDevs.Enabled = true;
+				GameController.recruitmentOfficeFull = false;
+			}
 		}
     }
 }

--- a/InformationAgeProject/InformationAgeProject/RecruitmentOffice.cs
+++ b/InformationAgeProject/InformationAgeProject/RecruitmentOffice.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//	Solution/Project:  InformationAgeProject/InformationAgeTests
+//	File Name:         RecruitmentOffice.cs
+//	Description:       RecruitmentOffice defines the Recruitment Office object
+//	Course:            CSCI-4250-002 - Software Engineering I
+//	Authors:           Anna Tredway, harwellab@etsu.edu
+//                     Bobby Mullins, mullinsbd@etsu.edu
+//                     Brandon Rhyno, rhynob@etsu.edu
+//                     Magnus Allen, allenmv@etsu.edu
+//	Created:           Friday, November 12, 2021
+//	Copyright:         Golden Cows Team, 2021
+//
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,15 +21,29 @@ using System.Threading.Tasks;
 
 namespace InformationAgeProject
 {
+    /// <summary>
+    /// RecruitmentOffice Class: Hosts methods/properties needed to manipulate the game's recruitment office.
+    /// </summary>
     public class RecruitmentOffice
     {
+        //Private player developer count
         private int _devs;
 
+        /// <summary>
+        /// RecruitmentOffice Constructor: Parameterized constructor that defines a
+        /// newly instantiated recruitmnet office. 
+        /// </summary>
+        /// <param name="devs">Player's total developer count</param>
         public RecruitmentOffice(int devs)
         {
             _devs = devs;
         }
 
+        /// <summary>
+        /// RecruitNewDev Method: Adds an addtional developer to the player's total
+        /// developer count.
+        /// </summary>
+        /// <returns></returns>
         public int RecruitNewDev()
         {
             _devs += 1;

--- a/InformationAgeProject/InformationAgeProject/obj/Debug/InformationAgeProject.csproj.FileListAbsolute.txt
+++ b/InformationAgeProject/InformationAgeProject/obj/Debug/InformationAgeProject.csproj.FileListAbsolute.txt
@@ -51,3 +51,4 @@ C:\Users\tnbra\OneDrive\School\Seinor\Fall Semester\Software Engineering\SE Proj
 C:\Users\tnbra\OneDrive\School\Seinor\Fall Semester\Software Engineering\SE Project\GoldenCowsProject\InformationAgeProject\InformationAgeProject\obj\Debug\InformationAgeProject.StatsForm.resources
 C:\Users\tnbra\OneDrive\School\Seinor\Fall Semester\Software Engineering\SE Project\GoldenCowsProject\InformationAgeProject\InformationAgeProject\obj\Debug\InformationAgeProject.csproj.SuggestedBindingRedirects.cache
 C:\Users\annah\Documents\GoldenCowsProject\InformationAgeProject\InformationAgeProject\obj\Debug\InformationAgeProject.StatsForm.resources
+C:\Users\annah\Documents\GoldenCowsProject\InformationAgeProject\InformationAgeProject\obj\Debug\InformationAgeProject.csproj.AssemblyReference.cache

--- a/InformationAgeProject/InformationAgeProject/obj/Debug/InformationAgeProject.csproj.FileListAbsolute.txt
+++ b/InformationAgeProject/InformationAgeProject/obj/Debug/InformationAgeProject.csproj.FileListAbsolute.txt
@@ -14,7 +14,6 @@ C:\Users\annah\Documents\GoldenCowsProject\InformationAgeProject\InformationAgeP
 C:\Users\annah\Documents\GoldenCowsProject\InformationAgeProject\InformationAgeProject\obj\Debug\InformationAgeProject.exe
 C:\Users\annah\Documents\GoldenCowsProject\InformationAgeProject\InformationAgeProject\obj\Debug\InformationAgeProject.pdb
 C:\Users\annah\Documents\GoldenCowsProject\InformationAgeProject\InformationAgeProject\bin\Debug\InformationAgeProject.pdb
-C:\Users\annah\Documents\GoldenCowsProject\InformationAgeProject\InformationAgeProject\obj\Debug\InformationAgeProject.csproj.AssemblyReference.cache
 C:\Users\storm.LAPTOP-VUPILJ1S\Documents\GitHub\GoldenCowsProject\InformationAgeProject\InformationAgeProject\bin\Debug\InformationAgeProject.exe.config
 C:\Users\storm.LAPTOP-VUPILJ1S\Documents\GitHub\GoldenCowsProject\InformationAgeProject\InformationAgeProject\bin\Debug\InformationAgeProject.exe
 C:\Users\storm.LAPTOP-VUPILJ1S\Documents\GitHub\GoldenCowsProject\InformationAgeProject\InformationAgeProject\bin\Debug\InformationAgeProject.pdb
@@ -51,3 +50,4 @@ C:\Users\tnbra\OneDrive\School\Seinor\Fall Semester\Software Engineering\SE Proj
 C:\Users\tnbra\OneDrive\School\Seinor\Fall Semester\Software Engineering\SE Project\GoldenCowsProject\InformationAgeProject\InformationAgeProject\obj\Debug\InformationAgeProject.pdb
 C:\Users\tnbra\OneDrive\School\Seinor\Fall Semester\Software Engineering\SE Project\GoldenCowsProject\InformationAgeProject\InformationAgeProject\obj\Debug\InformationAgeProject.StatsForm.resources
 C:\Users\tnbra\OneDrive\School\Seinor\Fall Semester\Software Engineering\SE Project\GoldenCowsProject\InformationAgeProject\InformationAgeProject\obj\Debug\InformationAgeProject.csproj.SuggestedBindingRedirects.cache
+C:\Users\annah\Documents\GoldenCowsProject\InformationAgeProject\InformationAgeProject\obj\Debug\InformationAgeProject.StatsForm.resources

--- a/InformationAgeProject/InformationAgeTests/InformationAgeTests.csproj
+++ b/InformationAgeProject/InformationAgeTests/InformationAgeTests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="GameControllerTests.cs" />
     <Compile Include="AdditionalProjectFeaturesTests.cs" />
     <Compile Include="ProjectProgressTests.cs" />
+    <Compile Include="SystemTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\InformationAgeProject\InformationAgeProject.csproj">

--- a/InformationAgeProject/InformationAgeTests/SystemTests.cs
+++ b/InformationAgeProject/InformationAgeTests/SystemTests.cs
@@ -1,0 +1,71 @@
+﻿///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+//	Solution/Project:  InformationAgeProject/InformationAgeTests
+//	File Name:         SystemTests.cs
+//	Description:       Hosts the SystemTests class for unit testing Information Age's primary functionality (on an Epic level)
+//	Course:            CSCI-4250-002 - Software Engineering I
+//	Authors:           Anna Tredway, harwellab@etsu.edu
+//                     Bobby Mullins, mullinsbd@etsu.edu
+//                     Brandon Rhyno, rhynob@etsu.edu
+//                     Magnus Allen, allenmv@etsu.edu
+//	Created:           Saturday, November 13, 2021
+//	Copyright:         Golden Cows Team, 2021
+//
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+using InformationAgeProject;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InformationAgeTests
+{
+    [TestClass]
+    public class SystemTests
+    {
+        [TestMethod]
+        public void testRecruitmentOffice()
+        {
+            //Instantiate players, their main forms, team names, and a counter to keep track of player turns
+            MainForm[] playerForms = new MainForm[2];
+            int turnCounter = 0;
+            Player[] playerList = new Player[2];
+            playerForms = new MainForm[2];
+            string[] teamNames = { "a", "b" };
+
+
+            //Activates players, sets their team names, and instantiates their MainForms
+            for (int i = 0; i < 2; i++)
+            {
+                playerList[i] = new Player();
+                playerList[i].TeamName = teamNames[i];
+                playerForms[i] = new MainForm(playerList[i]);
+            }
+
+            //Isolate the player forms into a private objects
+            MainForm playerForm1 = playerForms[0];
+            MainForm playerForm2 = playerForms[1];
+            PrivateObject obj1 = new PrivateObject(playerForm1);
+            PrivateObject obj2 = new PrivateObject(playerForm2);
+
+            //Send 2 devs belonging to player 1, and recall them
+            obj1.Invoke("btnSendDevs_Click");
+            obj1.Invoke("btnRecallDevs_Click");
+
+            //Send 2 devs belonging to player 1, and leaving them until round's end
+            obj1.Invoke("btnSendDevs_Click");
+            obj1.Invoke("btnEndTurn_Click");
+
+            //End turn of player 2
+            obj2.Invoke("btnEndTurn_Click");
+
+            Player player = new Player();
+            player.TeamCount = (int)obj1.GetFieldOrProperty("TeamCount");
+
+            Assert.AreEqual(6, player.TeamCount);
+        }
+    }
+}


### PR DESCRIPTION
Completed player developer recruitment  functionality. It now tracks between rounds. Only one player can use the recruitment office per round. The appropriate developers are distributed accordingly at the end of each round, and the recruitment office is opened back up.